### PR TITLE
Fix file existence tag to avoid nil path errors

### DIFF
--- a/_plugins/file-exists.rb
+++ b/_plugins/file-exists.rb
@@ -11,12 +11,13 @@ module Jekyll
 
       # Adds the site source, so that it also works with a custom one
       site_source = context.registers[:site].config['source']
-      file_path = site_source + '/' + url
+      file_path = File.join(site_source, url).strip
 
       # Check if file exists (returns true or false)
-      "#{File.exist?(file_path.strip!)}"
+      "#{File.exist?(file_path)}"
     end
   end
 end
 
 Liquid::Template.register_tag('file_exists', Jekyll::FileExistsTag)
+


### PR DESCRIPTION
## Summary
- Use `File.join` and `strip` in `file_exists` plugin to safely build paths and check files

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68add96b3a44832398d7b1db055ef144