### PR TITLE
Add tests for cache bust helpers

### DIFF
--- a/test/cache_bust_test.rb
+++ b/test/cache_bust_test.rb
@@ -1,0 +1,31 @@
+require 'minitest/autorun'
+require 'digest/md5'
+
+# Stub Liquid to avoid loading the full gem in tests
+module Liquid
+  class Template
+    def self.register_filter(*); end
+  end
+end
+
+require_relative '../_plugins/cache-bust'
+
+class CacheBustTest < Minitest::Test
+  include Jekyll::CacheBust
+
+  def test_bust_file_cache_adds_md5_hash
+    file_name = '/assets/css/bootstrap.min.css'
+    result = bust_file_cache(file_name)
+    digest = Digest::MD5.hexdigest(File.read('assets/css/bootstrap.min.css'))
+    assert_equal "#{file_name}?#{digest}", result
+  end
+
+  def test_bust_css_cache_digests_all_sass_files
+    file_name = '/assets/css/main.css'
+    result = bust_css_cache(file_name)
+    contents = Dir['assets/_sass/**/*'].select { |f| File.file?(f) }.map { |f| File.read(f) }.join
+    digest = Digest::MD5.hexdigest(contents)
+    assert_equal "#{file_name}?#{digest}", result
+  end
+end
+


### PR DESCRIPTION
## Summary
- add minitest verifying `bust_file_cache` appends MD5 digest
- ensure `bust_css_cache` digests all Sass files

## Testing
- `ruby -Itest test/cache_bust_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68addb5e992c8323ae395ff44f987d39