### PR TITLE
chore: disable auto prettier workflow

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,14 +1,7 @@
 name: Prettier code formatter
 
 on:
-  pull_request:
-    branches:
-      - master
-      - main
-  push:
-    branches:
-      - master
-      - main
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- prevent Prettier workflow from running on pushes or PRs by only allowing manual workflow dispatch

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68addfc2fce08323b9addf1bd2553203