### PR TITLE
Enable future-dated posts for AIQM2 page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
 blog_name: "Miquel's Blog" # blog_name will be displayed in your blog page
 blog_description: Notes on computational protein engineering
 permalink: /blog/:year/:title/
+future: true # build posts with future dates
 lsi: false # produce an index for related posts
 
 # Pagination


### PR DESCRIPTION
## Summary
- Allow Jekyll to build posts dated in the future so project redirects resolve

## Testing
- `bundle install` (fails: 403 "Forbidden")
- `bundle exec jekyll build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aecc36d59c8323879e34ea1887ff56