### PR TITLE
Fix project links to blog posts

### DIFF
--- a/_projects/aiqm2-orca-sella.md
+++ b/_projects/aiqm2-orca-sella.md
@@ -1,7 +1,7 @@
 ---
 title: AIQM2 with ORCA and Sella
 description: Utilities coupling AIQM2 with ORCA and the Sella optimizer for geometry and transition-state searches
-redirect: /blog/2025/aiqm2-orca-sella/
+redirect: /blog/2025/AIQM2-ORCA-Sella/
 importance: 1
 category: work
 ---

--- a/_projects/protonation-optimizer.md
+++ b/_projects/protonation-optimizer.md
@@ -1,7 +1,7 @@
 ---
 title: Protonation Optimizer
 description: Tool for determining optimal amino acid protonation states via xTB calculations
-redirect: /blog/2025/protonation-optimizer/
+redirect: /blog/2025/Protonation-Optimizer/
 importance: 3
 category: work
 ---

--- a/_projects/qmmesp.md
+++ b/_projects/qmmesp.md
@@ -1,7 +1,7 @@
 ---
 title: QMMESP
 description: Environment-aware RESP charge derivation using QM/MM calculations
-redirect: /blog/2025/qmmesp/
+redirect: /blog/2025/QMMESP/
 importance: 2
 category: work
 ---


### PR DESCRIPTION
## Summary
- update the project card redirect URLs to match the generated blog post paths so the cards open the right articles

## Testing
- bundle exec jekyll build


------
https://chatgpt.com/codex/tasks/task_e_68c916a7a6b48323b3a9362f57dcb559